### PR TITLE
Added support for custom notification sounds

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -2,6 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:amazon="http://schemas.android.com/apk/lib/com.amazon.device.ads"
+    xmlns:rim="http://www.blackberry.com/ns/widgets"
     id="com.phonegap.plugins.PushPlugin"
     version="2.2.0">
 
@@ -75,7 +76,7 @@
             <preference name="showmessageinnotification" value="true" />
             <preference name="defaultnotificationmessage" value="You have a new message." />
 		</config-file>
-        
+
         <config-file target="AndroidManifest.xml" parent="/manifest">
             <!-- This permission ensures that no other application can intercept your ADM messages. "[YOUR PACKAGE NAME]" is your package name as defined in your <manifest> tag. -->
             <permission android:name="$PACKAGE_NAME.permission.RECEIVE_ADM_MESSAGE" android:protectionLevel="signature" />
@@ -99,13 +100,13 @@
                     <action android:name="com.amazon.device.messaging.intent.RECEIVE" />
                     <category android:name="$PACKAGE_NAME" />
                 </intent-filter>
-            </receiver>		
+            </receiver>
         </config-file>
-        
+
         <source-file src="src/amazon/PushPlugin.java" target-dir="src/com/amazon/cordova/plugin" />
         <source-file src="src/amazon/ADMMessageHandler.java" target-dir="src/com/amazon/cordova/plugin" />
         <source-file src="src/amazon/ADMHandlerActivity.java" target-dir="src/com/amazon/cordova/plugin" />
-       		
+
 	</platform>
 
 	<!-- ios -->
@@ -125,8 +126,20 @@
 
 	</platform>
 
-  <!-- wp8 -->
-  <platform name="wp8">
+    <!-- blackberry10 -->
+    <platform name="blackberry10">
+        <dependency id="com.blackberry.push" />
+        <dependency id="com.blackberry.invoked" />
+        <config-file target="www/config.xml" parent="/widget">
+            <feature name="PushPlugin" value="PushPlugin" />
+        </config-file>
+        <js-module src="www/blackberry10/PushPluginProxy.js" name="PushPluginProxy" >
+            <runs />
+        </js-module>
+    </platform>
+
+    <!-- wp8 -->
+    <platform name="wp8">
 
     <config-file target="config.xml" parent="/*">
       <feature name="PushPlugin">

--- a/plugin.xml
+++ b/plugin.xml
@@ -128,6 +128,7 @@
 
     <!-- blackberry10 -->
     <platform name="blackberry10">
+        <dependency id="com.blackberry.app" />
         <dependency id="com.blackberry.push" />
         <dependency id="com.blackberry.invoked" />
         <config-file target="www/config.xml" parent="/widget">

--- a/www/blackberry10/PushPluginProxy.js
+++ b/www/blackberry10/PushPluginProxy.js
@@ -124,7 +124,7 @@ module.exports = {
             pushTransportReadyCallback = ops.pushTransportReadyCallback,
             launchApplicationOnPush = ops.launchApplicationOnPush;
 
-            ecb = ops.ecb,
+            ecb = ops.ecb;
 
         blackberry.push.PushService.create(ops, function(obj) {
             pushServiceObj = obj;
@@ -227,5 +227,5 @@ module.exports = {
             });
         }
     }
-}
+};
 require("cordova/exec/proxy").add("PushPlugin", module.exports);

--- a/www/blackberry10/PushPluginProxy.js
+++ b/www/blackberry10/PushPluginProxy.js
@@ -124,7 +124,7 @@ module.exports = {
             pushTransportReadyCallback = ops.pushTransportReadyCallback,
             launchApplicationOnPush = ops.launchApplicationOnPush;
 
-            ecb = ops.ecb,
+            ecb = ops.ecb;
 
         blackberry.push.PushService.create(ops, function(obj) {
             pushServiceObj = obj;
@@ -229,5 +229,5 @@ module.exports = {
             });
         }
     }
-}
+};
 require("cordova/exec/proxy").add("PushPlugin", module.exports);

--- a/www/blackberry10/PushPluginProxy.js
+++ b/www/blackberry10/PushPluginProxy.js
@@ -124,7 +124,7 @@ module.exports = {
             pushTransportReadyCallback = ops.pushTransportReadyCallback,
             launchApplicationOnPush = ops.launchApplicationOnPush;
 
-            ecb = ops.ecb;
+            ecb = ops.ecb,
 
         blackberry.push.PushService.create(ops, function(obj) {
             pushServiceObj = obj;
@@ -227,5 +227,5 @@ module.exports = {
             });
         }
     }
-};
+}
 require("cordova/exec/proxy").add("PushPlugin", module.exports);

--- a/www/blackberry10/PushPluginProxy.js
+++ b/www/blackberry10/PushPluginProxy.js
@@ -107,7 +107,7 @@ function onInvoked(invokeRequest) {
     if (invokeRequest.action && invokeRequest.action == "bb.action.PUSH") {
         if (ecb) {
             pushPayload = pushServiceObj.extractPushPayload(invokeRequest);
-            
+
             try {
                 // Only check for feature options in the payload if we're not in fullscreen.
                 if (blackberry.app.windowState !== "fullscreen") {
@@ -115,13 +115,14 @@ function onInvoked(invokeRequest) {
                     var reader = new FileReader();
                     reader.onload = function(fileReaderEvent) {
                         var decodedPayload = fileReaderEvent.target.result;
+                        var payload = JSON.parse(decodedPayload);
                         // Check for a "sound" property, indicating the desire to play a custom notification sound.
-                        if (decodedPayload.sound && typeof Media !== "undefined") {
-                            var sound = new Media(decodedPayload.sound);
+                        if (payload.sound && typeof Media !== "undefined") {
+                            var sound = new Media(payload.sound);
                             sound.play();
                         }
                     };
-                    reader.readAsText(pushPayload, "UTF-8");
+                    reader.readAsText(pushPayload.data, "UTF-8");
                 }
             } catch(e) {
                 // Do nothing.

--- a/www/blackberry10/PushPluginProxy.js
+++ b/www/blackberry10/PushPluginProxy.js
@@ -117,8 +117,8 @@ function onInvoked(invokeRequest) {
                         var decodedPayload = fileReaderEvent.target.result;
                         var payload = JSON.parse(decodedPayload);
                         // Check for a "sound" property, indicating the desire to play a custom notification sound.
-                        if (payload.sound && typeof Media !== "undefined") {
-                            var sound = new Media(payload.sound);
+                        if (payload.sound) {
+                            var sound = new Audio(payload.sound);
                             sound.play();
                         }
                     };

--- a/www/blackberry10/PushPluginProxy.js
+++ b/www/blackberry10/PushPluginProxy.js
@@ -1,0 +1,231 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var pushServiceObj,
+    ecb;
+
+function createChannel(success, error) {
+    if (pushServiceObj) {
+        pushServiceObj.createChannel(function(result, token) {
+            if (result == blackberry.push.PushService.SUCCESS) {
+                if (success) {
+                    success({
+                        status: result,
+                        token: token
+                    });
+                }
+            } else {
+                if (result == blackberry.push.PushService.INTERNAL_ERROR) {
+                    error("Error: An internal error occurred during the create channel. Try registering again.");
+                } else if (result == blackberry.push.PushService.CREATE_SESSION_NOT_DONE) {
+                    error("Error: No call to blackberry.push.PushService.create "
+                          + "was done before creating the channel. It usually means a programming error.");
+                } else if (result == blackberry.push.PushService.MISSING_PORT_FROM_PPG) {
+                    error("Error: A port could not be obtained from the "
+                          + "PPG during the create channel. Try registering again.");
+                } else if (result == blackberry.push.PushService.INVALID_DEVICE_PIN) {
+                    // This error code only applies to a consumer application using the public/BIS PPG
+                    error("Error: The PPG obtained the device's PIN during "
+                          + "the create channel and considered it invalid. Try registering again.");
+                } else if (result == blackberry.push.PushService.INVALID_PROVIDER_APPLICATION_ID) {
+                    // This error code only applies to a consumer application using the public/BIS PPG
+                    error("Error: The application ID was considered invalid or missing during the create channel.");
+                } else if (result == blackberry.push.PushService.INVALID_PPG_SUBSCRIBER_STATE) {
+                    // This error code only applies to a consumer application using the public/BIS PPG
+                    error("Error: The subscriber on the PPG end reached an "
+                          + "invalid state. Report this issue to the BlackBerry support team.");
+                } else if (result == blackberry.push.PushService.EXPIRED_AUTHENTICATION_TOKEN_PROVIDED_TO_PPG) {
+                    // This error code only applies to a consumer application using the public/BIS PPG
+                    error("Error: An expired authentication token was"
+                          + "passed to the PPG internally during the create channel. Try registering again.");
+                } else if (result == blackberry.push.PushService.INVALID_AUTHENTICATION_TOKEN_PROVIDED_TO_PPG) {
+                    // This error code only applies to a consumer application using the public/BIS PPG
+                    error("Error: An invalid authentication token was passed "
+                          + "to the PPG internally during the create channel. Report this issue to the BlackBerry support team.");
+                } else if (result == blackberry.push.PushService.PPG_SUBSCRIBER_LIMIT_REACHED) {
+                    // This error code only applies to a consumer application using the public/BIS PPG
+                    error("Error: Too many devices have already peformed a "
+                          + "create channel for this application ID. Contact BlackBerry to increase the subscription limit for this app.");
+                } else if (result == blackberry.push.PushService.INVALID_OS_VERSION_OR_DEVICE_MODEL_NUMBER) {
+                    // This error code only applies to a consumer application using the public/BIS PPG
+                    error("Error: This device was found to have an invalid OS "
+                          + " version or device model number during the create channel. Consider updating the OS on the device.");
+                } else if (result == blackberry.push.PushService.MISSING_PPG_URL) {
+                    // This error code only applies to a consumer application using the public/BIS PPG
+                    error("Error: The PPG URL was considered "
+                          + "invalid or missing during the create channel.");
+                } else if (result == blackberry.push.PushService.PUSH_TRANSPORT_UNAVAILABLE) {
+                    // This error code only applies to a consumer application using the public/BIS PPG
+                    error("Error: Create channel failed as the push transport "
+                          + "is unavailable. Verify your mobile network and/or Wi-Fi are turned on. If they are on, you will "
+                          + "be notified when the push transport is available again.");
+                } else if (result == blackberry.push.PushService.PPG_SERVER_ERROR) {
+                    // This error code only applies to a consumer application using the public/BIS PPG
+                    error("Error: Create channel failed as the PPG is "
+                          + "currently returning a server error. You will be notified when the PPG is available again.");
+                } else if (result == blackberry.push.PushService.MISSING_SUBSCRIPTION_RETURN_CODE_FROM_PPG) {
+                    // This error code only applies to a consumer application using the public/BIS PPG
+                    error("Error: There was an internal issue obtaining "
+                          + "the subscription return code from the PPG during the create channel. Try registering again.");
+                } else if (result == blackberry.push.PushService.INVALID_PPG_URL) {
+                    // This error code only applies to a consumer application using the public/BIS PPG
+                    error("Error: The PPG URL was considered invalid during the create channel.");
+                } else {
+                    error("Error: Received error code (" + result + ") when creating channel");
+                }
+            }
+
+
+        });
+    }
+
+
+}
+
+function onInvoked(invokeRequest) {
+    var pushPayload,
+        pushCallback;
+
+    if (invokeRequest.action && invokeRequest.action == "bb.action.PUSH") {
+        if (ecb) {
+            pushCallback = eval(ecb);
+
+            if (typeof pushCallback === "function") {
+                pushPayload = pushServiceObj.extractPushPayload(invokeRequest);
+                pushCallback(pushPayload);
+            }
+        }
+    }
+}
+
+module.exports = {
+
+    register: function(success, error, args) {
+        var ops = args[0],
+            simChangeCallback = ops.simChangeCallback,
+            pushTransportReadyCallback = ops.pushTransportReadyCallback,
+            launchApplicationOnPush = ops.launchApplicationOnPush;
+
+            ecb = ops.ecb,
+
+        blackberry.push.PushService.create(ops, function(obj) {
+            pushServiceObj = obj;
+
+            // Add an event listener to handle incoming invokes
+            document.addEventListener("invoked", onInvoked, false);
+
+            if (launchApplicationOnPush) {
+                pushServiceObj.launchApplicationOnPush(launchApplicationOnPush , function (result) {
+                    if (result == blackberry.push.PushService.INTERNAL_ERROR) {
+                        error("Error: An internal error occurred while calling launchApplicationOnPush.");
+                    } else if (result == blackberry.push.PushService.CREATE_SESSION_NOT_DONE) {
+                        error("Error: Called launchApplicationOnPush without an "
+                              + "existing session. It usually means a programming error.");
+                    } else {
+                        error("Error: Received error code (" + result + ") after calling launchApplicationOnPush.");
+                    }
+                });
+            }
+
+            createChannel(success, error);
+        }, function(result) {
+            if (result == blackberry.push.PushService.INTERNAL_ERROR) {
+                error("Error: An internal error occurred while calling "
+                      + "blackberry.push.PushService.create. Try restarting the application.");
+            } else if (result == blackberry.push.PushService.INVALID_PROVIDER_APPLICATION_ID) {
+                // This error only applies to consumer applications that use a public/BIS PPG
+                error("Error: Called blackberry.push.PushService.create with a missing "
+                      + "or invalid appId value. It usually means a programming error.");
+            } else if (result == blackberry.push.PushService.MISSING_INVOKE_TARGET_ID) {
+                error("Error: Called blackberry.push.PushService.create with a missing "
+                      + "invokeTargetId value. It usually means a programming error.");
+            } else if (result == blackberry.push.PushService.SESSION_ALREADY_EXISTS) {
+                error("Error: Called blackberry.push.PushService.create with an appId or "
+                      + "invokeTargetId value that matches another application. It usually means a "
+                      + "programming error.");
+            } else {
+                error("Error: Received error code (" + result + ") after "
+                      + "calling blackberry.push.PushService.create.");
+            }
+        }, simChangeCallback, pushTransportReadyCallback);
+    },
+
+    unregister: function(success, error, args) {
+        if (pushServiceObj) {
+            pushServiceObj.destroyChannel(function(result) {
+
+                document.removeEventListener("invoked", onInvoked, false);
+
+                if (result == blackberry.push.PushService.SUCCESS ||
+                    result == blackberry.push.PushService.CHANNEL_ALREADY_DESTROYED ||
+                    result == blackberry.push.PushService.CHANNEL_ALREADY_DESTROYED_BY_PROVIDER ||
+                    result == blackberry.push.PushService.CHANNEL_SUSPENDED_BY_PROVIDER ||
+                    result == blackberry.push.PushService.PPG_SUBSCRIBER_NOT_FOUND ||
+                    result == blackberry.push.PushService.CREATE_CHANNEL_NOT_DONE) {
+
+                    success( { status: result } );
+                } else {
+                    if (result == blackberry.push.PushService.INTERNAL_ERROR) {
+                        error("Error: An internal error occurred during "
+                            + "the destroy channel. Try unregistering again.");
+                    } else if (result == blackberry.push.PushService.CREATE_SESSION_NOT_DONE) {
+                        error("Error: No call to blackberry.push.PushService.create "
+                            + "was done before destroying the channel. It usually means a programming error.");
+                    } else if (result == blackberry.push.PushService.INVALID_DEVICE_PIN) {
+                        // This error code only applies to a consumer application using the public/BIS PPG
+                        error("Error: The PPG obtained the device's PIN during "
+                            + "the destroy channel and considered it invalid. Try unregistering again.");
+                    } else if (result == blackberry.push.PushService.INVALID_PROVIDER_APPLICATION_ID) {
+                        // This error code only applies to a consumer application using the public/BIS PPG
+                        error("Error: The application ID was considered invalid or missing during the destroy channel.");
+                    } else if (result == blackberry.push.PushService.INVALID_PPG_SUBSCRIBER_STATE) {
+                        // This error code only applies to a consumer application using the public/BIS PPG
+                        error("Error: The subscriber on the PPG end reached an "
+                            + "invalid state. Report this issue to the BlackBerry support team.");
+                    } else if (result == blackberry.push.PushService.EXPIRED_AUTHENTICATION_TOKEN_PROVIDED_TO_PPG) {
+                        // This error code only applies to a consumer application using the public/BIS PPG
+                        error("Error: An expired authentication token was"
+                            + "passed to the PPG internally during the destroy channel. Try unregistering again.");
+                    } else if (result == blackberry.push.PushService.INVALID_AUTHENTICATION_TOKEN_PROVIDED_TO_PPG) {
+                        // This error code only applies to a consumer application using the public/BIS PPG
+                        error("Error: An invalid authentication token was passed "
+                            + "to the PPG internally during the destroy channel. Report this issue to the BlackBerry support team.");
+                    } else if (result == blackberry.push.PushService.PUSH_TRANSPORT_UNAVAILABLE) {
+                        // This error code only applies to a consumer application using the public/BIS PPG
+                        error("Error: Destroy channel failed as the push transport "
+                            + "is unavailable. Verify your mobile network and/or Wi-Fi are turned on. If they are on, you will "
+                            + "be notified when the push transport is available again.");
+                    } else if (result == blackberry.push.PushService.PPG_SERVER_ERROR) {
+                        // This error code only applies to a consumer application using the public/BIS PPG
+                        error("Error: Destroy channel failed as the PPG is "
+                            + "currently returning a server error. You will be notified when the PPG is available again.");
+                    } else if (result == blackberry.push.PushService.INVALID_PPG_URL) {
+                        // This error code only applies to a consumer application using the public/BIS PPG
+                        error("Error: The PPG URL was considered invalid during the destroy channel.");
+                    } else {
+                        error("Error: Received error code (" + result + ") from the destroy channel.");
+                    }
+                }
+            });
+        }
+    }
+}
+require("cordova/exec/proxy").add("PushPlugin", module.exports);

--- a/www/blackberry10/PushPluginProxy.js
+++ b/www/blackberry10/PushPluginProxy.js
@@ -125,7 +125,7 @@ function onInvoked(invokeRequest) {
                     reader.readAsText(pushPayload.data, "UTF-8");
                 }
             } catch(e) {
-                // Do nothing.
+                console.error(e);
             } finally {
                 pushCallback = eval(ecb);
                 if (typeof pushCallback === "function") {

--- a/www/blackberry10/PushPluginProxy.js
+++ b/www/blackberry10/PushPluginProxy.js
@@ -134,13 +134,15 @@ module.exports = {
 
             if (launchApplicationOnPush) {
                 pushServiceObj.launchApplicationOnPush(launchApplicationOnPush , function (result) {
-                    if (result == blackberry.push.PushService.INTERNAL_ERROR) {
-                        error("Error: An internal error occurred while calling launchApplicationOnPush.");
-                    } else if (result == blackberry.push.PushService.CREATE_SESSION_NOT_DONE) {
-                        error("Error: Called launchApplicationOnPush without an "
-                              + "existing session. It usually means a programming error.");
-                    } else {
-                        error("Error: Received error code (" + result + ") after calling launchApplicationOnPush.");
+                    if (result != blackberry.push.PushService.SUCCESS ) {
+                        if (result == blackberry.push.PushService.INTERNAL_ERROR) {
+                            error("Error: An internal error occurred while calling launchApplicationOnPush.");
+                        } else if (result == blackberry.push.PushService.CREATE_SESSION_NOT_DONE) {
+                            error("Error: Called launchApplicationOnPush without an "
+                                  + "existing session. It usually means a programming error.");
+                        } else {
+                            error("Error: Received error code (" + result + ") after calling launchApplicationOnPush.");
+                        }
                     }
                 });
             }


### PR DESCRIPTION
This change assumes that notification sounds should be handled on the level of the Cordova plugin to line up functionality with iOS.
The file name of the audio file is taken from the "sound" property of the push payload. This should be, for example, "/res/alert.mp3" if the file is located in "www/res/alert.mp3".
org.apache.cordova.media is required to play the sound.
