### PR TITLE
launchApplicationOnPush can be false

### DIFF
--- a/www/blackberry10/PushPluginProxy.js
+++ b/www/blackberry10/PushPluginProxy.js
@@ -131,21 +131,18 @@ module.exports = {
 
             // Add an event listener to handle incoming invokes
             document.addEventListener("invoked", onInvoked, false);
-
-            if (launchApplicationOnPush) {
-                pushServiceObj.launchApplicationOnPush(launchApplicationOnPush , function (result) {
-                    if (result != blackberry.push.PushService.SUCCESS ) {
-                        if (result == blackberry.push.PushService.INTERNAL_ERROR) {
-                            error("Error: An internal error occurred while calling launchApplicationOnPush.");
-                        } else if (result == blackberry.push.PushService.CREATE_SESSION_NOT_DONE) {
-                            error("Error: Called launchApplicationOnPush without an "
-                                  + "existing session. It usually means a programming error.");
-                        } else {
-                            error("Error: Received error code (" + result + ") after calling launchApplicationOnPush.");
-                        }
+            pushServiceObj.launchApplicationOnPush(launchApplicationOnPush , function (result) {
+                if (result != blackberry.push.PushService.SUCCESS ) {
+                    if (result == blackberry.push.PushService.INTERNAL_ERROR) {
+                        error("Error: An internal error occurred while calling launchApplicationOnPush.");
+                    } else if (result == blackberry.push.PushService.CREATE_SESSION_NOT_DONE) {
+                        error("Error: Called launchApplicationOnPush without an "
+                              + "existing session. It usually means a programming error.");
+                    } else {
+                        error("Error: Received error code (" + result + ") after calling launchApplicationOnPush.");
                     }
-                });
-            }
+                }
+            });
 
             createChannel(success, error);
         }, function(result) {


### PR DESCRIPTION
If launchApplicationOnPush is false, the if check will not allow pushServiceObj.launchApplicationOnPush(false, function to run.

Therefore, we don't need to check anymore.
